### PR TITLE
Stop creating cloud accounts.

### DIFF
--- a/core/models/user.py
+++ b/core/models/user.py
@@ -290,6 +290,8 @@ def create_new_accounts(username, selected_provider=None):
     return identities
 
 def create_new_account_for(provider, user):
+    #Here at the MOC we do not need to create the account
+    return None
     from service.driver import get_account_driver
     existing_user_list = provider.identity_set.values_list('created_by__username', flat=True)
     if user.username in existing_user_list:


### PR DESCRIPTION
Currently when a user logs into to atmosphere it will attempt to create a clould account.  At the MOC we create the cloud account so there is no need to do anything else.

For the general solution, that could be migrated into the cyverse upstream - this should be conditional on a flag in the settings/local.py - but we do not need to do this here and now.